### PR TITLE
Adding additional checks in HMGM controller to verify transcript exists

### DIFF
--- a/src/main/java/edu/indiana/dlib/amppd/service/impl/HmgmServiceImpl.java
+++ b/src/main/java/edu/indiana/dlib/amppd/service/impl/HmgmServiceImpl.java
@@ -33,6 +33,10 @@ public class HmgmServiceImpl implements HmgmService {
 			String pathToFile = datasetPath;
 			if(new File(pathToFile + COMPLETE_EXTENSION).exists()) {
 				response.setComplete(true);
+				return response;
+			}
+			if(!new File(pathToFile).exists()) {
+				return response;
 			}
 			File tempFile = new File(datasetPath + TEMP_EXTENSION);
 			if(reset) {


### PR DESCRIPTION
Attempts to fix errors when completing the transcript by returning early in the method if 1) The transcript has been completed or 2) The file no longer exists.  