### PR TITLE
Amp 731 change external

### DIFF
--- a/src/main/java/edu/indiana/dlib/amppd/model/Content.java
+++ b/src/main/java/edu/indiana/dlib/amppd/model/Content.java
@@ -1,8 +1,8 @@
 package edu.indiana.dlib.amppd.model;
 
-import java.util.HashMap;
-
 import javax.persistence.MappedSuperclass;
+
+import org.hibernate.annotations.Type;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -19,6 +19,7 @@ import lombok.ToString;
 @ToString(callSuper=true)
 public abstract class Content extends Dataentity {
 
+    @Type(type="text")
     private String externalId;
 
 }

--- a/src/main/java/edu/indiana/dlib/amppd/model/Content.java
+++ b/src/main/java/edu/indiana/dlib/amppd/model/Content.java
@@ -19,6 +19,6 @@ import lombok.ToString;
 @ToString(callSuper=true)
 public abstract class Content extends Dataentity {
 
-    private HashMap<String, String> externalIds;
+    private String externalId;
 
 }

--- a/src/main/java/edu/indiana/dlib/amppd/service/impl/BatchServiceImpl.java
+++ b/src/main/java/edu/indiana/dlib/amppd/service/impl/BatchServiceImpl.java
@@ -110,7 +110,7 @@ public class BatchServiceImpl implements BatchService {
 
 		// Get an existing item if found in this collection, otherwise create a new one. 
 		log.info("BATCH PROCESSING : Get an existing item if found in this collection, otherwise create a new one");
-		Item item = getItem(collection, batchFile.getItemName(), batchFile.getItemDescription(), username, batchFile.getExternalItemId(), batchFile.getExternalSource());
+		Item item = getItem(collection, batchFile.getItemName(), batchFile.getItemDescription(), username, batchFile.getExternalItemId());
 		/*
 		 * if(errors.size()>0) return;
 		 */
@@ -430,14 +430,14 @@ public class BatchServiceImpl implements BatchService {
 	/*
 	 * Gets an Item object.  If one already exists, 
 	 */
-	private Item getItem(Collection collection, String itemName, String itemDescription, String createdBy, String externalItemId, String externalSource) {
+	private Item getItem(Collection collection, String itemName, String itemDescription, String createdBy, String externalItemId) {
 		Item item = null;
 		Set<Item> items = collection.getItems();
 		boolean found = false;
 		if(items!=null) {
 			log.info("BATCH PROCESSING : check for matching item in this collection"); 
 			for(Item i : items) {
-				if(!externalSource.isBlank() && !externalItemId.isBlank()) 
+				if(!externalItemId.isBlank()) 
 				{
 					if(i.getExternalId() != null && i.getExternalId() == externalItemId)
 					{
@@ -445,7 +445,7 @@ public class BatchServiceImpl implements BatchService {
 						item = i;
 						if(!i.getName().contentEquals(itemName))
 						{
-							log.info("BATCH PROCESSING : External Item id  and external source combination already exists"); 
+							log.info("BATCH PROCESSING : External Item id already exists"); 
 							//batchValidationResponse.addProcessingError("ERROR: In row "+currRow+" Item name already exists");
 							itemRepository.updateTitle(itemName,i.getId());
 						}

--- a/src/main/java/edu/indiana/dlib/amppd/service/impl/BatchServiceImpl.java
+++ b/src/main/java/edu/indiana/dlib/amppd/service/impl/BatchServiceImpl.java
@@ -396,7 +396,7 @@ public class BatchServiceImpl implements BatchService {
 			{ 
 				if((p.getName() != null && p.getName().contentEquals(batchFile.getPrimaryfileName()) ) ) 
 				{
-					if(item.getExternalIds() != null && item.getExternalIds().containsKey(batchFile.getExternalItemId())) 
+					if(item.getExternalId() != null && item.getExternalId() == batchFile.getExternalItemId()) 
 					{
 						if(item.getCollection() != null && item.getCollection().getId() == batchfileCollection.getId()) 
 						{ 
@@ -439,7 +439,7 @@ public class BatchServiceImpl implements BatchService {
 			for(Item i : items) {
 				if(!externalSource.isBlank() && !externalItemId.isBlank()) 
 				{
-					if(i.getExternalIds() != null && i.getExternalIds().containsKey(externalItemId))
+					if(i.getExternalId() != null && i.getExternalId() == externalItemId)
 					{
 						found = true;
 						item = i;
@@ -465,10 +465,8 @@ public class BatchServiceImpl implements BatchService {
 		if(item==null && !found) {
 			item = new Item();
 			item.setName(itemName);
-			if(!externalSource.isBlank() && !externalItemId.isBlank()) {
-				HashMap<String, String> externalIds = new HashMap<String, String>();
-				externalIds.put(externalItemId, externalSource);
-				item.setExternalIds(externalIds);
+			if(!externalItemId.isBlank()) {
+				item.setExternalId(externalItemId);
 			}
 			item.setDescription(itemDescription);
 			item.setCreatedBy(createdBy);

--- a/src/test/java/edu/indiana/dlib/amppd/testData/ModelTemplates.java
+++ b/src/test/java/edu/indiana/dlib/amppd/testData/ModelTemplates.java
@@ -26,7 +26,7 @@ public class ModelTemplates implements TemplateLoader {
 		// TODO Auto-generated method stub
 				
 		    Fixture.of(Collection.class).addTemplate("valid", new Rule() {{
-	    	add("externalIds", new HashMap<String, String>());
+			add("externalId", new String());
 		    add("id", random(Long.class, range(1L, 200L)));
 	    	add("name", "Collection ${id}");
 	    	add("description", "Description for ${name}");	
@@ -51,7 +51,7 @@ public class ModelTemplates implements TemplateLoader {
 			add("originalFilename", firstName());
 		  	add("pathname", "C:/New Folder/${name}");
 		  	add("mediaInfo", "{}");
-		  	add("externalIds", new HashMap<String, String>());
+		  	add("externalId", new String());
 		  	}});
 		 
 		 
@@ -66,7 +66,7 @@ public class ModelTemplates implements TemplateLoader {
 	    	//add("collection", one(Collection.class, "valid"));
 			add("primaryfiles", new HashSet<Primaryfile>()); 
 			add("supplements", new HashSet<ItemSupplement>()); 
-			add("externalIds", new HashMap<String, String>());
+		  	add("externalId", new String());
 			}});
 			
 	    Fixture.of(Primaryfile.class).addTemplate("valid", new Rule() {{
@@ -82,7 +82,7 @@ public class ModelTemplates implements TemplateLoader {
 			add("originalFilename", firstName());
 			add("pathname", "C:/New Folder/${name}");
 		  	add("mediaInfo", "{}");
-			add("externalIds", new HashMap<String, String>());
+		  	add("externalId", new String());
 			}});
 	    
 		
@@ -98,7 +98,7 @@ public class ModelTemplates implements TemplateLoader {
 			add("originalFilename", firstName());
 		  	add("pathname", "C:/New Folder/${name}");
 		  	add("mediaInfo", "{}");
-		  	add("externalIds", new HashMap<String, String>());
+		  	add("externalId", new String());
 			}});
 		 
 	    
@@ -127,13 +127,13 @@ public class ModelTemplates implements TemplateLoader {
 			add("originalFilename", firstName());
 		  	add("pathname", "C:/New Folder/${name}");
 		  	add("mediaInfo", "{}");
-		  	add("externalIds", new HashMap<String, String>());
+		  	add("externalId", new String());
 		  }});
 		 
 	  
 	    Fixture.of(Unit.class).addTemplate("valid", new Rule() {{ 
-	    	//add("collections", has(3).of(Collection.class, "valid")); 
-	    	add("externalIds", new HashMap<String, String>());
+	    	//add("collections", has(3).of(Collection.class, "valid"));
+		  	add("externalId", new String());
 	    	add("id", random(Long.class, range(1L, 200L)));
 			add("name", "Unit ${id}");
 	    	add("description", "Description for ${name}");	


### PR DESCRIPTION
Changing externalIds to externalId. Originally a HashMap of the source ID and source Name, it is now a text field.  Unit test fixtures have been updated to use the new column.  Also, the field External Source has been removed where it is unnecessary in batch processing.  