### PR TITLE
Amp 710 editor auth

### DIFF
--- a/src/main/java/edu/indiana/dlib/amppd/config/AmppdUiPropertyConfig.java
+++ b/src/main/java/edu/indiana/dlib/amppd/config/AmppdUiPropertyConfig.java
@@ -23,6 +23,7 @@ public class AmppdUiPropertyConfig {
     @NotNull private String url;
     @NotNull private String documentRoot;
     @NotNull private String symlinkDir;
+    @NotNull private String hmgmSecretKey;
 
 }
 

--- a/src/main/java/edu/indiana/dlib/amppd/controller/HmgmController.java
+++ b/src/main/java/edu/indiana/dlib/amppd/controller/HmgmController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
+import edu.indiana.dlib.amppd.service.AuthService;
 import edu.indiana.dlib.amppd.service.HmgmNerService;
 import edu.indiana.dlib.amppd.service.HmgmTranscriptService;
 import edu.indiana.dlib.amppd.web.SaveTranscriptRequest;
@@ -23,6 +24,12 @@ public class HmgmController {
 		
 	@Autowired HmgmTranscriptService hmgmTranscriptService;
 	@Autowired HmgmNerService hmgmNerService;
+	@Autowired AuthService authService;
+	
+	@GetMapping(path = "/hmgm/authorize-editor", produces = "application/json")
+	public @ResponseBody Boolean authorizeEditor(String authString, String userToken, String editorInput) {	
+		return authService.compareAuthStrings(authString, userToken, editorInput);
+	}
 	
 	@GetMapping(path = "/hmgm/transcript-editor", produces = "application/json")
 	public @ResponseBody TranscriptEditorResponse transcriptEditor(String datasetPath, boolean reset) {			

--- a/src/main/java/edu/indiana/dlib/amppd/service/AuthService.java
+++ b/src/main/java/edu/indiana/dlib/amppd/service/AuthService.java
@@ -1,0 +1,14 @@
+package edu.indiana.dlib.amppd.service;
+
+public interface AuthService {
+
+	/**
+	 * Compares input values to a sha-256 auth string
+	 * @param authString SHA-256 hash string
+	 * @param userToken User supplied token
+	 * @param editorInput Input file path
+	 * @return
+	 */
+	boolean compareAuthStrings(String authString, String userToken, String editorInput);
+
+}

--- a/src/main/java/edu/indiana/dlib/amppd/service/impl/AuthServiceImpl.java
+++ b/src/main/java/edu/indiana/dlib/amppd/service/impl/AuthServiceImpl.java
@@ -1,0 +1,35 @@
+package edu.indiana.dlib.amppd.service.impl;
+
+import java.security.NoSuchAlgorithmException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import edu.indiana.dlib.amppd.config.AmppdUiPropertyConfig;
+import edu.indiana.dlib.amppd.service.AuthService;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+public class AuthServiceImpl implements AuthService {
+
+	@Autowired
+	private AmppdUiPropertyConfig amppdUiPropertyConfig;
+	
+	@Override
+	public boolean compareAuthStrings(String authString, String userToken, String editorInput) {
+		try {
+			String hash = hashValues(userToken, editorInput);
+			return hash.equals(authString);
+		}
+		catch(Exception ex) {
+			log.error("Error comparing auth string: " + ex);
+		}
+		return false;
+	}
+	
+	private String hashValues(String userToken, String editorInput) throws NoSuchAlgorithmException {
+		String originalString = userToken + editorInput + amppdUiPropertyConfig.getHmgmSecretKey();
+		return org.apache.commons.codec.digest.DigestUtils.sha256Hex(originalString);
+	}
+}


### PR DESCRIPTION
Adds method to support the validation of auth strings for hmgm editors.  