### PR TITLE
Amp 710 editor auth

### DIFF
--- a/src/main/java/edu/indiana/dlib/amppd/config/JwtRequestFilter.java
+++ b/src/main/java/edu/indiana/dlib/amppd/config/JwtRequestFilter.java
@@ -16,6 +16,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import edu.indiana.dlib.amppd.model.AmpUser;
 import edu.indiana.dlib.amppd.service.AmpUserService;
+import edu.indiana.dlib.amppd.service.AuthService;
 import io.jsonwebtoken.ExpiredJwtException;
 
 @Component
@@ -24,9 +25,36 @@ public class JwtRequestFilter extends OncePerRequestFilter {
 	@Autowired
 	private AmpUserService jwtUserDetailsService;
 	
+	
 	@Autowired
 	private JwtTokenUtil jwtTokenUtil;
 	
+	@Autowired
+	private AmppdUiPropertyConfig amppdUIConfig;
+	
+
+	@Autowired
+	private AuthService authService;
+	
+	
+	private void CreateAnonymousAuth(HttpServletRequest request) {
+		AmpUser userDetails = new AmpUser();
+		userDetails.setEmail("none");
+		userDetails.setUsername("");
+	
+		UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken = new UsernamePasswordAuthenticationToken(
+				userDetails, null, null);
+
+		usernamePasswordAuthenticationToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+
+		SecurityContextHolder.getContext().setAuthentication(usernamePasswordAuthenticationToken);
+	}
+	private boolean ValidRefUrl(String referer) {
+		String cleanedRef = referer.replace("https://", "").replace("#/", "").replace("#", "").replace("localhost", "127.0.0.1");
+		String cleanedUiUrl = amppdUIConfig.getUrl().replace("https://", "").replace("#/", "").replace("#", "").replace("localhost", "127.0.0.1") + "timeliner.html";
+		logger.debug(cleanedUiUrl + " starts with " + cleanedRef + " : " + cleanedUiUrl.startsWith(cleanedRef));
+		return cleanedRef.startsWith(cleanedUiUrl);
+	}
 	@Override
 	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
 			throws ServletException, IOException {
@@ -34,33 +62,52 @@ public class JwtRequestFilter extends OncePerRequestFilter {
 			
 		String username = null;
 		String jwtToken = null;
-	
-		if (requestTokenHeader != null && requestTokenHeader.startsWith("Bearer ")) {
-			jwtToken = requestTokenHeader.substring(7);
-			try {
-				username = jwtTokenUtil.getUsernameFromToken(jwtToken);
-			} catch (IllegalArgumentException e) {
-				System.out.println("Unable to get JWT Token");
-			} catch (ExpiredJwtException e) {
-				System.out.println("JWT Token has expired");
-			}
-		} else {
-			logger.warn("JWT Token does not begin with Bearer String");
+
+		String authToken = null;
+		
+		
+		if(ValidRefUrl(request.getHeader("referer"))) {
+			CreateAnonymousAuth(request);
 		}
-	
-		if (username != null && SecurityContextHolder.getContext().getAuthentication() == null) {
-			AmpUser userDetails = this.jwtUserDetailsService.getUser(username);
-		
-			if (jwtTokenUtil.validateToken(jwtToken, userDetails)) {
-				UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken = new UsernamePasswordAuthenticationToken(
-						userDetails, null, null);/*userDetails.getAuthorities()*/
-		
-				usernamePasswordAuthenticationToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
-		
-				SecurityContextHolder.getContext().setAuthentication(usernamePasswordAuthenticationToken);
-	
+		else if (requestTokenHeader != null && requestTokenHeader.startsWith("AMPPD ")) {
+			authToken = requestTokenHeader.substring(6);
+			String[] parts = authToken.split(";;;;");
+			String editorInput = parts[0];
+			String userToken = parts[1];
+			String authString = parts[2];
+			
+			if(authService.compareAuthStrings(authString, userToken, editorInput)){
+				CreateAnonymousAuth(request);
 			}
-	
+			
+		}
+		else {
+			if (requestTokenHeader != null && requestTokenHeader.startsWith("Bearer ")) {
+				jwtToken = requestTokenHeader.substring(7);
+				try {
+					username = jwtTokenUtil.getUsernameFromToken(jwtToken);
+				} catch (IllegalArgumentException e) {
+					System.out.println("Unable to get JWT Token");
+				} catch (ExpiredJwtException e) {
+					System.out.println("JWT Token has expired");
+				}
+			} else {
+				logger.warn("JWT Token does not begin with Bearer String");
+			}
+		
+			if (username != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+				AmpUser userDetails = this.jwtUserDetailsService.getUser(username);
+			
+				if (jwtTokenUtil.validateToken(jwtToken, userDetails)) {
+					UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken = new UsernamePasswordAuthenticationToken(
+							userDetails, null, null);/*userDetails.getAuthorities()*/
+			
+					usernamePasswordAuthenticationToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+			
+					SecurityContextHolder.getContext().setAuthentication(usernamePasswordAuthenticationToken);
+				}
+		
+			}
 		}
 	
 		chain.doFilter(request, response);

--- a/src/main/java/edu/indiana/dlib/amppd/config/JwtRequestFilter.java
+++ b/src/main/java/edu/indiana/dlib/amppd/config/JwtRequestFilter.java
@@ -50,8 +50,8 @@ public class JwtRequestFilter extends OncePerRequestFilter {
 		SecurityContextHolder.getContext().setAuthentication(usernamePasswordAuthenticationToken);
 	}
 	private boolean ValidRefUrl(String referer) {
-		String cleanedRef = referer.replace("https://", "").replace("#/", "").replace("#", "").replace("localhost", "127.0.0.1");
-		String cleanedUiUrl = amppdUIConfig.getUrl().replace("https://", "").replace("#/", "").replace("#", "").replace("localhost", "127.0.0.1") + "timeliner.html";
+		String cleanedRef = referer.replace("https://", "").replace("http://", "").replace("#/", "").replace("#", "").replace("localhost", "127.0.0.1");
+		String cleanedUiUrl = amppdUIConfig.getUrl().replace("https://", "").replace("http://", "").replace("#/", "").replace("#", "").replace("localhost", "127.0.0.1") + "timeliner.html";
 		logger.debug(cleanedUiUrl + " starts with " + cleanedRef + " : " + cleanedUiUrl.startsWith(cleanedRef));
 		return cleanedRef.startsWith(cleanedUiUrl);
 	}

--- a/src/main/java/edu/indiana/dlib/amppd/config/SecurityConfig.java
+++ b/src/main/java/edu/indiana/dlib/amppd/config/SecurityConfig.java
@@ -98,9 +98,9 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 			.antMatchers(HttpMethod.POST, "/account/reset-password").permitAll()
 			.antMatchers(HttpMethod.POST, "/account/activate").permitAll()
 			.antMatchers(HttpMethod.POST, "/account/reset-password-getEmail").permitAll()
-			.antMatchers(HttpMethod.POST, "/hmgm/authorize-editor").permitAll()
+			.antMatchers(HttpMethod.GET, "/hmgm/authorize-editor").permitAll()
+			
 			// TODO remove below hmgm paths after we done development with HMGM
-			.antMatchers("/hmgm/**").permitAll()
 			.anyRequest().authenticated().and().
 			exceptionHandling().authenticationEntryPoint(jwtAuthenticationEntryPoint).and().sessionManagement()
 			.sessionCreationPolicy(SessionCreationPolicy.STATELESS);

--- a/src/main/java/edu/indiana/dlib/amppd/config/SecurityConfig.java
+++ b/src/main/java/edu/indiana/dlib/amppd/config/SecurityConfig.java
@@ -98,6 +98,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 			.antMatchers(HttpMethod.POST, "/account/reset-password").permitAll()
 			.antMatchers(HttpMethod.POST, "/account/activate").permitAll()
 			.antMatchers(HttpMethod.POST, "/account/reset-password-getEmail").permitAll()
+			.antMatchers(HttpMethod.POST, "/hmgm/authorize-editor").permitAll()
 			// TODO remove below hmgm paths after we done development with HMGM
 			.antMatchers("/hmgm/**").permitAll()
 			.anyRequest().authenticated().and().

--- a/src/main/java/edu/indiana/dlib/amppd/controller/DashboardController.java
+++ b/src/main/java/edu/indiana/dlib/amppd/controller/DashboardController.java
@@ -1,11 +1,5 @@
 package edu.indiana.dlib.amppd.controller;
 
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Date;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -15,7 +9,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import edu.indiana.dlib.amppd.service.DashboardService;
-import edu.indiana.dlib.amppd.service.impl.AmpUserServiceImpl;
 import edu.indiana.dlib.amppd.web.DashboardResponse;
 import edu.indiana.dlib.amppd.web.DashboardSearchQuery;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/edu/indiana/dlib/amppd/controller/HmgmController.java
+++ b/src/main/java/edu/indiana/dlib/amppd/controller/HmgmController.java
@@ -32,7 +32,7 @@ public class HmgmController {
 	}
 	
 	@GetMapping(path = "/hmgm/transcript-editor", produces = "application/json")
-	public @ResponseBody TranscriptEditorResponse transcriptEditor(String datasetPath, boolean reset) {			
+	public @ResponseBody TranscriptEditorResponse transcriptEditor(String datasetPath, boolean reset) {		
 		return hmgmTranscriptService.getTranscript(datasetPath, reset);
 	}
 	

--- a/src/main/java/edu/indiana/dlib/amppd/service/AuthService.java
+++ b/src/main/java/edu/indiana/dlib/amppd/service/AuthService.java
@@ -11,13 +11,5 @@ public interface AuthService {
 	 */
 	boolean compareAuthStrings(String authString, String userToken, String editorInput);
 	
-	/**
-	 * Check to see if it is an authorized user, first based on JWT set user, then token.
-	 * @param authString
-	 * @param userToken
-	 * @param editorInput
-	 * @return
-	 */
-	boolean isAuthorized(String authString, String userToken, String editorInput);
 
 }

--- a/src/main/java/edu/indiana/dlib/amppd/service/AuthService.java
+++ b/src/main/java/edu/indiana/dlib/amppd/service/AuthService.java
@@ -10,5 +10,14 @@ public interface AuthService {
 	 * @return
 	 */
 	boolean compareAuthStrings(String authString, String userToken, String editorInput);
+	
+	/**
+	 * Check to see if it is an authorized user, first based on JWT set user, then token.
+	 * @param authString
+	 * @param userToken
+	 * @param editorInput
+	 * @return
+	 */
+	boolean isAuthorized(String authString, String userToken, String editorInput);
 
 }

--- a/src/main/java/edu/indiana/dlib/amppd/service/impl/AuthServiceImpl.java
+++ b/src/main/java/edu/indiana/dlib/amppd/service/impl/AuthServiceImpl.java
@@ -6,6 +6,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import edu.indiana.dlib.amppd.config.AmppdUiPropertyConfig;
+import edu.indiana.dlib.amppd.model.AmpUser;
+import edu.indiana.dlib.amppd.service.AmpUserService;
 import edu.indiana.dlib.amppd.service.AuthService;
 import lombok.extern.slf4j.Slf4j;
 
@@ -15,6 +17,9 @@ public class AuthServiceImpl implements AuthService {
 
 	@Autowired
 	private AmppdUiPropertyConfig amppdUiPropertyConfig;
+	
+	@Autowired
+	private AmpUserService ampUserService;
 	
 	@Override
 	public boolean compareAuthStrings(String authString, String userToken, String editorInput) {
@@ -31,5 +36,21 @@ public class AuthServiceImpl implements AuthService {
 	private String hashValues(String userToken, String editorInput) throws NoSuchAlgorithmException {
 		String originalString = userToken + editorInput + amppdUiPropertyConfig.getHmgmSecretKey();
 		return org.apache.commons.codec.digest.DigestUtils.sha256Hex(originalString);
+	}
+
+	@Override
+	public boolean isAuthorized(String authString, String userToken, String editorInput) {
+		try {
+			AmpUser user = ampUserService.getCurrentUser();
+			return true;
+		}
+		catch(RuntimeException ex) {
+			// Current user not found.  Check token
+			return compareAuthStrings(authString, userToken, editorInput);
+		}
+		catch(Exception ex) {
+			// We caught an exception...
+			return false;
+		}
 	}
 }

--- a/src/main/java/edu/indiana/dlib/amppd/service/impl/AuthServiceImpl.java
+++ b/src/main/java/edu/indiana/dlib/amppd/service/impl/AuthServiceImpl.java
@@ -37,20 +37,4 @@ public class AuthServiceImpl implements AuthService {
 		String originalString = userToken + editorInput + amppdUiPropertyConfig.getHmgmSecretKey();
 		return org.apache.commons.codec.digest.DigestUtils.sha256Hex(originalString);
 	}
-
-	@Override
-	public boolean isAuthorized(String authString, String userToken, String editorInput) {
-		try {
-			AmpUser user = ampUserService.getCurrentUser();
-			return true;
-		}
-		catch(RuntimeException ex) {
-			// Current user not found.  Check token
-			return compareAuthStrings(authString, userToken, editorInput);
-		}
-		catch(Exception ex) {
-			// We caught an exception...
-			return false;
-		}
-	}
 }

--- a/src/main/java/edu/indiana/dlib/amppd/service/impl/HmgmTranscriptServiceImpl.java
+++ b/src/main/java/edu/indiana/dlib/amppd/service/impl/HmgmTranscriptServiceImpl.java
@@ -9,8 +9,10 @@ import java.nio.file.Files;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import edu.indiana.dlib.amppd.service.AuthService;
 import edu.indiana.dlib.amppd.service.HmgmTranscriptService;
 import edu.indiana.dlib.amppd.web.SaveTranscriptRequest;
 import edu.indiana.dlib.amppd.web.TranscriptEditorRequest;
@@ -23,10 +25,11 @@ public class HmgmTranscriptServiceImpl implements HmgmTranscriptService {
 	private String TEMP_EXTENSION=".tmp";
 	private String COMPLETE_EXTENSION=".complete";
 	
+	
 	/*
 	 * Get the json of a transcript
 	 */
-	public TranscriptEditorResponse getTranscript(String datasetPath, boolean reset) {			
+	public TranscriptEditorResponse getTranscript(String datasetPath, boolean reset) {	
 		JSONParser parser = new JSONParser();
 		TranscriptEditorResponse response = new TranscriptEditorResponse();
 		try {


### PR DESCRIPTION
Adding additional checking to the JWTFilter to check for different types of auth strings.  If it is referred by the timeliner url, approve auth.  Otherwise, if the auth header starts with AMPPD, validate the auth string using tokenization.  Otherwise validate JWT as normal.  