### PR TITLE
Amp 937 refresh results job

### DIFF
--- a/src/main/java/edu/indiana/dlib/amppd/AmppdApplication.java
+++ b/src/main/java/edu/indiana/dlib/amppd/AmppdApplication.java
@@ -5,6 +5,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.ApplicationContext;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 import edu.indiana.dlib.amppd.config.AmppdPropertyConfig;
 import edu.indiana.dlib.amppd.config.AmppdUiPropertyConfig;
@@ -12,6 +13,7 @@ import edu.indiana.dlib.amppd.config.GalaxyPropertyConfig;
 import lombok.extern.slf4j.Slf4j;
 
 @SpringBootApplication
+@EnableScheduling
 //@EnableJdbcHttpSession
 @EnableJpaRepositories("edu.indiana.dlib.amppd.repository")
 @EnableConfigurationProperties({GalaxyPropertyConfig.class, AmppdPropertyConfig.class, AmppdUiPropertyConfig.class})

--- a/src/main/java/edu/indiana/dlib/amppd/config/WorkflowResultsScheduler.java
+++ b/src/main/java/edu/indiana/dlib/amppd/config/WorkflowResultsScheduler.java
@@ -17,7 +17,7 @@ public class WorkflowResultsScheduler {
    
    // On the 20 minute mark
    // THis will run every 5 seconds for testing @Scheduled(cron = "0/5 * * ? * *")
-   @Scheduled(cron = "0 0/20 * ? * *")
+   @Scheduled(cron = "${amppd.refreshWorkflowResultsStatusCron}")
    public void refreshStatus() {
       System.out.println("Starting refresh status at " + sdf.format(new Date()));
       workflowResultService.refreshIncompleteResults();
@@ -26,7 +26,7 @@ public class WorkflowResultsScheduler {
    
    
    // Every day at 1 am
-   @Scheduled(cron = "0 0 1 1/1 * *")
+   @Scheduled(cron = "${amppd.refreshWorkflowResultsAllCron}")
    public void refreshAllResults() {
 	      System.out.println("Starting refreshWorkflowResultsIterative at " + sdf.format(new Date()));
 	      workflowResultService.refreshWorkflowResultsIterative();

--- a/src/main/java/edu/indiana/dlib/amppd/config/WorkflowResultsScheduler.java
+++ b/src/main/java/edu/indiana/dlib/amppd/config/WorkflowResultsScheduler.java
@@ -1,0 +1,36 @@
+package edu.indiana.dlib.amppd.config;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import edu.indiana.dlib.amppd.service.WorkflowResultService;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+@Component
+public class WorkflowResultsScheduler {
+   private SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
+
+   @Autowired
+   private WorkflowResultService workflowResultService;
+   
+   // On the 20 minute mark
+   // THis will run every 5 seconds for testing @Scheduled(cron = "0/5 * * ? * *")
+   @Scheduled(cron = "0 0/20 * ? * *")
+   public void refreshStatus() {
+      System.out.println("Starting refresh status at " + sdf.format(new Date()));
+      workflowResultService.refreshIncompleteResults();
+      System.out.println("Finished running refresh status at " + sdf.format(new Date()));
+   }
+   
+   
+   // Every day at 1 am
+   //@Scheduled(cron = "0 0 1 1/1 * *")
+   @Scheduled(cron = "0/5 * * ? * *")
+   public void refreshAllResults() {
+	      System.out.println("Starting refreshWorkflowResultsIterative at " + sdf.format(new Date()));
+	      workflowResultService.refreshWorkflowResultsIterative();
+	      System.out.println("Finished refreshWorkflowResultsIterative at " + sdf.format(new Date()));
+   }
+}

--- a/src/main/java/edu/indiana/dlib/amppd/config/WorkflowResultsScheduler.java
+++ b/src/main/java/edu/indiana/dlib/amppd/config/WorkflowResultsScheduler.java
@@ -26,8 +26,7 @@ public class WorkflowResultsScheduler {
    
    
    // Every day at 1 am
-   //@Scheduled(cron = "0 0 1 1/1 * *")
-   @Scheduled(cron = "0/5 * * ? * *")
+   @Scheduled(cron = "0 0 1 1/1 * *")
    public void refreshAllResults() {
 	      System.out.println("Starting refreshWorkflowResultsIterative at " + sdf.format(new Date()));
 	      workflowResultService.refreshWorkflowResultsIterative();

--- a/src/main/java/edu/indiana/dlib/amppd/repository/WorkflowResultRepository.java
+++ b/src/main/java/edu/indiana/dlib/amppd/repository/WorkflowResultRepository.java
@@ -19,6 +19,9 @@ public interface WorkflowResultRepository extends PagingAndSortingRepository<Wor
 	boolean invocationExists(@Param("invocationId") String invocationId);
 	
 	@Query(value = "select min(dateRefreshed) from WorkflowResult d where d.primaryfileId = :primaryfileId")
-	Date findOldestDateRefreshedByPrimaryfileId(Long primaryfileId);	
+	Date findOldestDateRefreshedByPrimaryfileId(Long primaryfileId);
+	
+	@Query(value = "select d from WorkflowResult d where d.dateRefreshed < :dateObsolete")
+	List<WorkflowResult> findObsolete(Date dateObsolete);
 	
 }

--- a/src/main/java/edu/indiana/dlib/amppd/service/WorkflowResultService.java
+++ b/src/main/java/edu/indiana/dlib/amppd/service/WorkflowResultService.java
@@ -54,4 +54,9 @@ public interface WorkflowResultService {
 	 * @return
 	 */
 	public boolean setResultIsFinal(long workflowResultId, boolean isFinal);
+	
+	/**
+	 * Refreshes incomplete workflow results status values
+	 */
+	public void refreshIncompleteResults();
 }

--- a/src/main/java/edu/indiana/dlib/amppd/service/impl/WorkflowResultServiceImpl.java
+++ b/src/main/java/edu/indiana/dlib/amppd/service/impl/WorkflowResultServiceImpl.java
@@ -108,24 +108,24 @@ public class WorkflowResultServiceImpl implements WorkflowResultService {
 	 */
 	private List<WorkflowResult> refreshResultsStatusAsNeeded(List<WorkflowResult> WorkflowResults) {
 		for(WorkflowResult result : WorkflowResults) {
-			if (shouldRefreshResultStatus(result)) {
-				result = refreshResultStatus(result);
-			}
+			result = refreshResultStatus(result);
 		}
 		return WorkflowResults;
 	}
-		
+	
+	public void refreshIncompleteResults() {	
+		WorkflowResultSearchQuery query = new WorkflowResultSearchQuery();
+		GalaxyJobState[] filterByStatuses = {GalaxyJobState.IN_PROGRESS, GalaxyJobState.SCHEDULED, GalaxyJobState.UNKNOWN};
+		query.setFilterByStatuses(filterByStatuses);
+		WorkflowResultResponse response = workflowResultRepository.searchResults(query);
+		refreshResultsStatusAsNeeded(response.getRows());
+	}
+	
 	/**
 	 * @see edu.indiana.dlib.amppd.service.WorkflowResultService.getWorkflowResults(WorkflowResultSearchQuery)
 	 */
 	public WorkflowResultResponse getWorkflowResults(WorkflowResultSearchQuery query){
-		//List<WorkflowResult> results = (List<WorkflowResult>) cache.get(CACHE_KEY, false);		
-		//if(results!=null) {
-		//	return results;
-		//}
-		
 		WorkflowResultResponse response = workflowResultRepository.searchResults(query);
-		refreshResultsStatusAsNeeded(response.getRows());
 		return response;
 	}
 	
@@ -170,7 +170,8 @@ public class WorkflowResultServiceImpl implements WorkflowResultService {
 	/**
 	 * @see edu.indiana.dlib.amppd.service.WorkflowResultService.refreshWorkflowResultsIterative()
 	 */
-	public List<WorkflowResult> refreshWorkflowResultsIterative() {				
+	public List<WorkflowResult> refreshWorkflowResultsIterative() {
+		
 		List<WorkflowResult> allResults = new ArrayList<WorkflowResult>();
 		List<Primaryfile> primaryfiles = primaryfileRepository.findByHistoryIdNotNull();
 		log.info("Found " + primaryfiles.size() + " primaryfiles with Galaxy history ...");
@@ -221,11 +222,20 @@ public class WorkflowResultServiceImpl implements WorkflowResultService {
 				log.error("Failed to refresh results for primaryfile " + primaryfile.getId(), e);
 			}
 		}
+		List<WorkflowResult> deletedResults = deleteObsoleteWorkflowResults();
 				
 		log.info("Successfully refreshed " + allResults.size() + " WorkflowResults iteratively.");
 		return allResults;
 	}
-	
+	private List<WorkflowResult> deleteObsoleteWorkflowResults() {
+		Date dateObsolete = DateUtils.addMinutes(new Date(), -REFRESH_TABLE_MINUTES);
+		List<WorkflowResult> toDelete = workflowResultRepository.findObsolete(dateObsolete);
+		
+		workflowResultRepository.deleteAll(toDelete);
+		
+		log.info("Deleted " + toDelete.size() + " workflow results");
+		return toDelete;
+	}
 	/**
 	 * @see edu.indiana.dlib.amppd.service.WorkflowResultService.refreshWorkflowResultsLumpsum()
 	 */

--- a/src/main/java/edu/indiana/dlib/amppd/service/impl/WorkflowResultServiceImpl.java
+++ b/src/main/java/edu/indiana/dlib/amppd/service/impl/WorkflowResultServiceImpl.java
@@ -119,6 +119,7 @@ public class WorkflowResultServiceImpl implements WorkflowResultService {
 		query.setFilterByStatuses(filterByStatuses);
 		WorkflowResultResponse response = workflowResultRepository.searchResults(query);
 		refreshResultsStatusAsNeeded(response.getRows());
+		log.debug("Refreshed the status of " + response.getRows().size());
 	}
 	
 	/**
@@ -227,6 +228,10 @@ public class WorkflowResultServiceImpl implements WorkflowResultService {
 		log.info("Successfully refreshed " + allResults.size() + " WorkflowResults iteratively.");
 		return allResults;
 	}
+	/**
+	 * Delete results that haven't been refreshed in a given period of time
+	 * @return a list of deleted workflow results 
+	 */
 	private List<WorkflowResult> deleteObsoleteWorkflowResults() {
 		Date dateObsolete = DateUtils.addMinutes(new Date(), -REFRESH_TABLE_MINUTES);
 		List<WorkflowResult> toDelete = workflowResultRepository.findObsolete(dateObsolete);

--- a/src/main/java/edu/indiana/dlib/amppd/web/WorkflowResultSearchQuery.java
+++ b/src/main/java/edu/indiana/dlib/amppd/web/WorkflowResultSearchQuery.java
@@ -1,5 +1,6 @@
 package edu.indiana.dlib.amppd.web;
 
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
@@ -7,6 +8,22 @@ import lombok.Data;
 
 @Data
 public class WorkflowResultSearchQuery {
+	public WorkflowResultSearchQuery(){
+		pageNum = 1;
+		resultsPerPage = Integer.MAX_VALUE;
+		filterBySubmitters = new String[0];
+		filterByWorkflows = new String[0];
+		filterByItems = new String[0];
+		filterByFiles = new String[0];
+		filterBySteps = new String[0];
+		filterByStatuses = new GalaxyJobState[0];
+		filterBySearchTerm = new String[0];
+		sortRule = new WorkflowResultSortRule();
+		sortRule.setColumnName("id");
+		sortRule.setOrderByDescending(false);
+		filterByDates = new ArrayList<Date>();
+		filterByFinal = false;
+	}
 	private int pageNum;
 	private int resultsPerPage;
 	private String[] filterBySubmitters;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -79,7 +79,7 @@ amppd.passwordResetTokenExpiration = ${AMPPD_PSWD_TOKEN_EXP:600}
 amppd.accountActivationTokenExpiration = ${AMPPD_ACCOUNT_TOKEN_EXP:604800}
 amppd.refreshResultsStatusMinutes = 10
 amppd.refreshResultsTableMinutes = 600
-amppd.refreshWorkflowResultsStatusCron = * 0/20 * ? * *
+amppd.refreshWorkflowResultsStatusCron = * 0/10 * ? * *
 amppd.refreshWorkflowResultsAllCron = 0 0 1 1/1 * *
 
 # Galaxy specific properties

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -79,6 +79,8 @@ amppd.passwordResetTokenExpiration = ${AMPPD_PSWD_TOKEN_EXP:600}
 amppd.accountActivationTokenExpiration = ${AMPPD_ACCOUNT_TOKEN_EXP:604800}
 amppd.refreshResultsStatusMinutes = 10
 amppd.refreshResultsTableMinutes = 600
+amppd.refreshWorkflowResultsStatusCron = * 0/20 * ? * *
+amppd.refreshWorkflowResultsAllCron = 0 0 1 1/1 * *
 
 # Galaxy specific properties
 galaxy.host = ${GALAXY_HOST:localhost}  

--- a/src/test/java/edu/indiana/dlib/amppd/service/WorkflowResultServiceTests.java
+++ b/src/test/java/edu/indiana/dlib/amppd/service/WorkflowResultServiceTests.java
@@ -32,7 +32,6 @@ import edu.indiana.dlib.amppd.web.WorkflowResultResponse;
 import edu.indiana.dlib.amppd.web.WorkflowResultSearchQuery;
 import edu.indiana.dlib.amppd.web.WorkflowResultSortRule;
 
-@Ignore
 @RunWith(SpringRunner.class)
 @SpringBootTest
 public class WorkflowResultServiceTests {

--- a/src/test/java/edu/indiana/dlib/amppd/service/WorkflowResultServiceTests.java
+++ b/src/test/java/edu/indiana/dlib/amppd/service/WorkflowResultServiceTests.java
@@ -32,6 +32,7 @@ import edu.indiana.dlib.amppd.web.WorkflowResultResponse;
 import edu.indiana.dlib.amppd.web.WorkflowResultSearchQuery;
 import edu.indiana.dlib.amppd.web.WorkflowResultSortRule;
 
+@Ignore
 @RunWith(SpringRunner.class)
 @SpringBootTest
 public class WorkflowResultServiceTests {


### PR DESCRIPTION
Creates a workflow result scheduler to run a job to refresh statuses every 20 minutes.  Also schedules a job to run every night which should cleanup the workflow results table.  