### PR TITLE
Adding username and environment to account approval email

### DIFF
--- a/src/main/java/edu/indiana/dlib/amppd/config/AmppdPropertyConfig.java
+++ b/src/main/java/edu/indiana/dlib/amppd/config/AmppdPropertyConfig.java
@@ -31,4 +31,5 @@ public class AmppdPropertyConfig {
     @NotNull private int passwordResetTokenExpiration;
     @NotNull private int accountActivationTokenExpiration;
     @NotNull private Boolean auth;
+    @NotNull private String environment;
 }

--- a/src/main/java/edu/indiana/dlib/amppd/service/impl/AmpUserServiceImpl.java
+++ b/src/main/java/edu/indiana/dlib/amppd/service/impl/AmpUserServiceImpl.java
@@ -366,7 +366,7 @@ public class AmpUserServiceImpl implements AmpUserService, UserDetailsService {
 			url = contextPath + "/account/approve/" + user.getId();
 			message = "A new user has registered and waiting approval. \n\n User Name:"+ user.getUsername()+"\n User Email: "+user.getEmail()+ "\n User ID: "+user.getId()+
 					"\n\n Click the link below to view and approve the new user. \n";
-			subject = "New User account request";
+			subject = amppdPropertyConfig.getEnvironment() + " New User account request: " + user.getUsername();
 			emailTo = ampAdmin;
 		}
 		else if(type.contentEquals("reset password"))

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -82,7 +82,7 @@ amppd.refreshResultsStatusMinutes = 10
 amppd.refreshResultsTableMinutes = 300
 amppd.refreshWorkflowResultsStatusCron = 0 0/10 6-18 ? * MON-FRI
 amppd.refreshWorkflowResultsAllCron = 0 0 1 ? * MON-FRI
-amppd.environment = "Test"
+amppd.environment = "Dev"
 
 # Galaxy specific properties
 galaxy.host = ${GALAXY_HOST:localhost}  

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -82,6 +82,7 @@ amppd.refreshResultsStatusMinutes = 10
 amppd.refreshResultsTableMinutes = 300
 amppd.refreshWorkflowResultsStatusCron = 0 0/10 6-18 ? * MON-FRI
 amppd.refreshWorkflowResultsAllCron = 0 0 1 ? * MON-FRI
+amppd.environment = "Test"
 
 # Galaxy specific properties
 galaxy.host = ${GALAXY_HOST:localhost}  


### PR DESCRIPTION
Adds username and environment to account approval request email. 

Calcium = Staging
Potassium = Test

Also adds a new property config variable (environment) to help with the subject line.  