### PR TITLE
Fixes for containerization:

### DIFF
--- a/src/main/java/edu/indiana/dlib/amppd/service/impl/FileStorageServiceImpl.java
+++ b/src/main/java/edu/indiana/dlib/amppd/service/impl/FileStorageServiceImpl.java
@@ -69,11 +69,11 @@ public class FileStorageServiceImpl implements FileStorageService {
 		config = amppdconfig;
 		try {
 			root = Paths.get(config.getFileStorageRoot());
-			if(!Files.exists(root)) {
+			if(!Files.exists(root)) {  // corner case where createDirectories() fails when it is a symlink
 				Files.createDirectories(root);	// creates root directory if not already exists
 			}
 			Path dropbox = Paths.get(config.getDropboxRoot());
-			if(!Files.exists(dropbox)) {
+			if(!Files.exists(dropbox)) {  // corner case where createDirectories() fails when it is a symlink
 				Files.createDirectories(dropbox);	// creates batch root directory if not already exists
 			}
 			log.info("File storage root directory " + root + " has been created." );

--- a/src/main/java/edu/indiana/dlib/amppd/service/impl/FileStorageServiceImpl.java
+++ b/src/main/java/edu/indiana/dlib/amppd/service/impl/FileStorageServiceImpl.java
@@ -69,9 +69,14 @@ public class FileStorageServiceImpl implements FileStorageService {
 		config = amppdconfig;
 		try {
 			root = Paths.get(config.getFileStorageRoot());
-			Files.createDirectories(root);	// creates root directory if not already exists
-			Files.createDirectories(Paths.get(config.getDropboxRoot()));	// creates batch root directory if not already exists
-			log.info("File storage root directory " + config.getFileStorageRoot() + " has been created." );
+			if(!Files.exists(root)) {
+				Files.createDirectories(root);	// creates root directory if not already exists
+			}
+			Path dropbox = Paths.get(config.getDropboxRoot());
+			if(!Files.exists(dropbox)) {
+				Files.createDirectories(dropbox);	// creates batch root directory if not already exists
+			}
+			log.info("File storage root directory " + root + " has been created." );
 		}
 		catch (IOException e) {
 			throw new StorageException("Failed to initialize file storage root directory " + config.getFileStorageRoot(), e);

--- a/src/main/java/edu/indiana/dlib/amppd/service/impl/PreprocessServiceImpl.java
+++ b/src/main/java/edu/indiana/dlib/amppd/service/impl/PreprocessServiceImpl.java
@@ -116,7 +116,7 @@ public class PreprocessServiceImpl implements PreprocessService {
 		String jsonpath = getMediaInfoJsonPath(filepath);
 		ProcessBuilder pb = new ProcessBuilder(
 				amppdPropertyConfig.getPythonPath(), 
-				amppdPropertyConfig.getMediaprobeDir() + "media_probe.py", 
+				amppdPropertyConfig.getMediaprobeDir() + "/media_probe.py", 
 				"--json", 
 				fileStorageService.absolutePathName(filepath));
 


### PR DESCRIPTION
* prepend a slash to /mediprobe.py
* don't fail when the media and dropbox dirs are symlinks