### PR TITLE
Update amp_build.py so it will copy the war so tomcat can redeploy

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.compile.nullAnalysis.mode": "automatic"
+}

--- a/amp_build.py
+++ b/amp_build.py
@@ -29,6 +29,11 @@ def main():
         logging.error("You must supply a destdir when building a package")
         exit(1)
 
+    if args.destdir and not Path(args.destdir).is_dir():
+        logging.error("Destination directory not actually a directory.")
+        exit(1)
+
+
     if 'JAVA_HOME' not in os.environ:
         logging.error("Please set the JAVA_HOME to a JDK11 Path (this won't build on JDK17)")
         exit(1)
@@ -49,6 +54,9 @@ def main():
 
     if not args.package:
         logging.info(f"The war file is in: {warfile}")
+        if args.destdir:
+            shutil.copy(warfile, args.destdir + "/rest.war")
+            logging.info(f"Copied warfile to {args.destdir}/rest.war")
         exit(0)
 
     # OK so the .war file is in the target directory.


### PR DESCRIPTION
This is a minor change for simplifying development in a VM.  It really has nothing to do with AMP-2511 but was a nice side effect while I was troubleshooting.

I use visual studio code to edit the java code on the VM (in $AMP_ROOT/src_repos/amppd) and when I want to try it on a running instance of AMP, from the amppd repo directory I'll run:  "./amp_build.py $AMP_ROOT/tomcat/webapps" which will build the warfile, copy it to the webapps directory, and then tomcat will deploy it.

