### PR TITLE
populate amp context in parameters to mgms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ HELP.md
 application-*.properties
 *MyController.java
 /.pydevproject
+
+# make sure not to include compiled things.
+/bin/
+*.class


### PR DESCRIPTION
This adds a bunch of context parameters to MGMs.  Galaxy ignores extra parameters so it should be safe to supply this data without interfering with anything.
